### PR TITLE
Realtek Idle Power to D0 instead of Idle Times

### DIFF
--- a/ASUS_G713PV_fix.bat
+++ b/ASUS_G713PV_fix.bat
@@ -65,11 +65,7 @@ if defined rollback (set hibernate=off) else (set hibernate=on)
 if defined rollback (set coreisolation=1) else (set coreisolation=0)
 if defined rollback (set policypwrdn=0) else (set policypwrdn=1)
 if defined rollback (set netACstby=1) else (set netACstby=0)
-::if defined rollback (set netDCstby=2) else (set netDCstby=0)
-if defined rollback (set nvidletime=04000000) else (set nvidletime=00000000)
-if defined rollback (set rtkidletime=05000000) else (set rtkidletime=00000000)
-if defined rollback (set rtkidlestate=03000000) else (set rtkidlestate=00000000)
-if defined rollback (set amdidletime=03000000) else (set amdidletime=00000000)
+if defined rollback (set PwrIdleState=03000000) else (set PwrIdleState=00000000)
 if defined rollback (set RB=ROLLBACK:) else (set RB=EXECUTE:)
 if defined rollback echo [6m[91mROLLBACK PROCEDURE TO DEFAULTS WILL BE APPLIED TO REGISTRY ENTRIES[0m
 
@@ -106,20 +102,14 @@ call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\4faab71a-92e5-4726-b531
 :: STRONGLY RECOMMENDED: Disable networking in standby in AC and/or DC for more quiet Modern Standby sleep!
 set "Step=3.2/ %RB% Networking connectivity in Standby (Disable networking in Standby for AC.)
 call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\%actpowplanguid%" "ACSettingIndex" "REG_DWORD" %netACstby%
-::set "Step=3.3/ %RB% Networking connectivity in DC Standby (Disable networking in Standby for DC.). Normally, not necessary in DC (Windows managed => no connectivity)
-::call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\%actpowplanguid%" "DCSettingIndex" "REG_DWORD" %netDCstby%
 
-:: 4 - Disable Idle times for nVidia HDA, AMD and Realtek audio drivers. Realtek forces last byte so infinite time instead of disable
-set "Step=4.1 et 4.2/ %RB% Disable Idle Time AC and DC for AMD Streaming Audio driver"
-call :ProcessKey add "%AMDstreaming%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %amdidletime% 
-call :ProcessKey add "%AMDstreaming%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %amdidletime%
-set "Step=5.1 et 5.2/ %RB% Disable Idle Time AC and DC for nVidia HDA driver"
-call :ProcessKey add "%nVidiaHDA%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %nvidletime% 
-call :ProcessKey add "%nVidiaHDA%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %nvidletime%
-set "Step=6.1 et 6.2/ %RB% Force Idle Power State to D0 in AC and DC for Realtek Audio driver"
-:: call :ProcessKey add "%Realtek%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %rtkidletime% 
-:: call :ProcessKey add "%Realtek%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %rtkidletime%
-call :ProcessKey add "%Realtek%\PowerSettings" "IdlePowerState" "REG_BINARY" %rtkidlestate%
+:: 4 - Force Idle states to D0 for nVidia HDA, AMD and Realtek audio drivers. Note Realtek forces Idle times, not Idle power state
+set "Step=4.1/ %RB% Force Idle Power State to D0 in AC and DC for AMD Streaming Audio driver"
+call :ProcessKey add "%AMDstreaming%\PowerSettings" "IdlePowerState" "REG_BINARY" %PwrIdleState%
+set "Step=4.2/ %RB% Force Idle Power State to D0 in AC and DC for nVidia HDA driver"
+call :ProcessKey add "%nVidiaHDA%\PowerSettings" "IdlePowerState" "REG_BINARY" %PwrIdleState%
+set "Step=4.3/ %RB% Force Idle Power State to D0 in AC and DC for Realtek Audio driver"
+call :ProcessKey add "%Realtek%\PowerSettings" "IdlePowerState" "REG_BINARY" %PwrIdleState%
 
 if defined quiet goto :eof
 if not defined admin goto :eof

--- a/ASUS_G713PV_fix.bat
+++ b/ASUS_G713PV_fix.bat
@@ -41,21 +41,22 @@ goto :ReadParams
 :EndReadParams
 
 :: Retreive legacy active power scheme GUID from 1st line of powercfg /q
-for /f "delims=" %%i in ('powercfg /q') do set actpowplan=%%i & goto :stop
-:stop
+for /f "delims=" %%i in ('powercfg /q') do set actpowplan=%%i & goto :EndGUID
+:EndGUID
 for /f "tokens=2 delims=:" %%i in ("%actpowplan%") do set actpowplan1=%%i
 for /f "tokens=1" %%i in ("%actpowplan1%") do set actpowplanguid=%%i
 
 set "RegKeyHeader=HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control"
 
-:: Retreive Media classes that need power Idle Time adjustment
-for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "NVIDIA*Audio"') do set nVidiaHDA=%%j & goto :stopnVidiaHDA
-:stopnVidiaHDA
-for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "Realtek*Audio"') do set Realtek=%%j & goto :stopRealtek
-:stopRealtek
-for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "AMD Streaming Audio"') do set AMDstreaming=%%j & goto :stopAMDstreaming
-:stopAMDstreaming
-:: Remove spaces in string
+:: Retreive Media classes that need power Idle Time adjustment.
+:: See https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/audio-device-class-inactivity-timer-implementation
+for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "NVIDIA*Audio"') do set nVidiaHDA=%%j & goto :EndnVidiaHDA
+:EndnVidiaHDA
+for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "Realtek*Audio"') do set Realtek=%%j & goto :EndRealtek
+:EndRealtek
+for /f "delims=" %%j in ('reg query "%RegKeyHeader%\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}" /s /f "AMD Streaming Audio"') do set AMDstreaming=%%j & goto :EndAMDstreaming
+:EndAMDstreaming
+:: Remove spaces in strings
 set nVidiaHDA=%nVidiaHDA: =%
 set Realtek=%Realtek: =%
 set AMDstreaming=%AMDstreaming: =%
@@ -66,7 +67,8 @@ if defined rollback (set policypwrdn=0) else (set policypwrdn=1)
 if defined rollback (set netACstby=1) else (set netACstby=0)
 ::if defined rollback (set netDCstby=2) else (set netDCstby=0)
 if defined rollback (set nvidletime=04000000) else (set nvidletime=00000000)
-if defined rollback (set rtkidletime=05000000) else (set rtkidletime=FFFFFFFF)
+if defined rollback (set rtkidletime=05000000) else (set rtkidletime=00000000)
+if defined rollback (set rtkidlestate=03000000) else (set rtkidlestate=00000000)
 if defined rollback (set amdidletime=03000000) else (set amdidletime=00000000)
 if defined rollback (set RB=ROLLBACK:) else (set RB=EXECUTE:)
 if defined rollback echo [6m[91mROLLBACK PROCEDURE TO DEFAULTS WILL BE APPLIED TO REGISTRY ENTRIES[0m
@@ -98,7 +100,7 @@ if not defined quiet %pausecls%
 set "Step=2/ %RB% Disable Core Isolation. After reboot, clic on 'Ignore' on yellow icon in 'Windows Sécurity'"
 call :ProcessKey add "%RegKeyHeader%\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" "Enabled" "REG_DWORD" %coreisolation%
 
-:: 3 - Set 3 important Power Management registry keys
+:: 3 - Set important Power Management registry keys
 set "Step=3.1/ %RB% policy for devices powering down while the system is running (power saving for AC and DC)
 call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\4faab71a-92e5-4726-b531-224559672d19\DefaultPowerSchemeValues\%actpowplanguid%" "ACSettingIndex" "REG_DWORD" %policypwrdn%
 :: STRONGLY RECOMMENDED: Disable networking in standby in AC and/or DC for more quiet Modern Standby sleep!
@@ -108,22 +110,23 @@ call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\f15576e8-98b7-4186-b944
 ::call :ProcessKey add "%RegKeyHeader%\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\%actpowplanguid%" "DCSettingIndex" "REG_DWORD" %netDCstby%
 
 :: 4 - Disable Idle times for nVidia HDA, AMD and Realtek audio drivers. Realtek forces last byte so infinite time instead of disable
-set "Step=4.1 et 4.2/ %RB% Modify Idle Time AC and DC for AMD Streaming Audio driver"
+set "Step=4.1 et 4.2/ %RB% Disable Idle Time AC and DC for AMD Streaming Audio driver"
 call :ProcessKey add "%AMDstreaming%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %amdidletime% 
 call :ProcessKey add "%AMDstreaming%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %amdidletime%
-set "Step=5.1 et 5.2/ %RB% Modify Idle Time AC and DC for nVidia HDA driver"
+set "Step=5.1 et 5.2/ %RB% Disable Idle Time AC and DC for nVidia HDA driver"
 call :ProcessKey add "%nVidiaHDA%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %nvidletime% 
 call :ProcessKey add "%nVidiaHDA%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %nvidletime%
-set "Step=6.1 et 6.2/ %RB% Modify Idle Time AC and DC for Realtek Audio driver"
-call :ProcessKey add "%Realtek%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %rtkidletime% 
-call :ProcessKey add "%Realtek%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %rtkidletime%
+set "Step=6.1 et 6.2/ %RB% Force Idle Power State to D0 in AC and DC for Realtek Audio driver"
+:: call :ProcessKey add "%Realtek%\PowerSettings" "ConservationIdleTime" "REG_BINARY" %rtkidletime% 
+:: call :ProcessKey add "%Realtek%\PowerSettings" "PerformanceIdleTime" "REG_BINARY" %rtkidletime%
+call :ProcessKey add "%Realtek%\PowerSettings" "IdlePowerState" "REG_BINARY" %rtkidlestate%
 
 if defined quiet goto :eof
 if not defined admin goto :eof
 echo:
 echo ]]]  Now, [6m[91mPlease REBOOT computer [0mto apply changes and parameters!
 echo:
-set /p continue="Do you want to reboot computer in 30 seconds? ([y]/n): "
+set /p continue="Do you want to reboot computer in 30 seconds? (Y/n): "
 if /I "%continue%" == "y" call :DoShutdown
 if /I "%continue%" == "" call :DoShutdown
 goto :eof

--- a/README.md
+++ b/README.md
@@ -6,28 +6,28 @@ Possibly works on other models from the same brand or product range too
 This .bat script sets a few parameters in Windows 11 registry, to stabilize ASUS G713PV laptop. 
 
 Designed and tested on this laptop. Likely to be used also on other laptop from same model range.
-## Issues covered
+## Issues solved
 Summary of different G713PV laptop issues, and status after using this utility batch script.
 
 **Solved** means here: **Not experienced this anymore** 
 
-|Issues on G713PV | After using utility | Comments |
-|-------|-------|---|
-|Laptop screen fast flickers and overall stability | Solved |Core Isolation OFF still needed for fast flickers and overall drivers stability|
-|Modern Standby with Hibernation/Fast Startup enabled freezes laptop on sleep | Solved |Bonus: Laptop now start really faster from Power Off or Hibernation!
-|Laptop crash/freeze on Wake up from Modern Standby|Solved|With Power Settings registry tweaks: Policy for devices powering down while the system is running|
-|nVidia nvlddmkm.dll crash during Modern Standby|Solved|No new event |
-|Sound issues, especially with nVidia HDA sound driver on external HDMI monitor: sound crackling, crash, HDMI sound channel loss. Can mess also Realtek sound on switching sound|Solved|AMD HD audio and nVidia HDA Audio Idle timeouts driver tweak stops messing and stabilizes whole laptop|
-|Random reboots|Seen with Bluetooth LE devices : Corsair mouse and Xbox Elite 2|No new reboot with latest Mediatek Bluetooth driver|
-|Black login screen (no *Windows Spotlight* image) after wake up from Modern Standby, with nVidia icons in taskbar disappear|Solved TBC |No new event seen |
+|Issues on G713PV |  Comments |
+|-------|-----|
+|Laptop screen fast flickers and overall stability |Core Isolation OFF still needed for fast flickers and overall drivers stability|
+|Modern Standby with Hibernation/Fast Startup enabled freezes laptop on sleep | Bonus: Laptop now start really faster from Power Off or Hibernation!
+|Laptop crash/freeze on Wake up from Modern Standby|With Power Settings registry tweaks: Policy for devices powering down while the system is running|
+|nVidia nvlddmkm.dll crash during Modern Standby|No new event |
+|Sound issues, especially with nVidia HDA sound driver on external HDMI monitor: sound crackling, crash, HDMI sound channel loss. Can mess also Realtek sound on switching sound|AMD HD audio and nVidia HDA Audio Idle Power to D0 driver tweak stops messing and stabilizes whole laptop|
+|Random reboots| Seen with Bluetooth LE devices : Corsair mouse and Xbox Elite 2. No new reboot with latest Mediatek Bluetooth driver|
+|Black login screen (no *Windows Spotlight* image) after wake up from Modern Standby, with nVidia icons in taskbar disappear|No new event seen after Idle power settings applied to audio devices nVidia, Realtek and AMD|
 
 ## Hints with Microsoft Modern Standby
 > [!WARNING]
 > Modern Standby is not and will never be former S3 sleep. 
 
-A new way Microsoft wants laptops to sleep, somehow like a smartphone.
+The way Microsoft wants laptops to sleep, somehow like a smartphone.
 
-Biggest difference stands in that sleep is not immediate. 
+Biggest difference with S3 stands in that sleep is not immediate. 
 
 Windows 11 runs an Orchestrator at standby start, performing maintenance tasks, before letting laptop to go to sleep. 
 
@@ -85,17 +85,17 @@ Software configuration used for set up and tests:
 >
 > Just rerun the script in such case after a driver installation.
 
-|Action|Command or Registry key: all HKLM keys expand to HKLM\SYSTEM\CurrentControlSet\Control\ |Default value|Target value set by script|
+|Action|Command or Registry key: all HKLM keys expand to HKLM\SYSTEM\CurrentControlSet\Control\ |Windows or driver value|New tweaked value|
 |:-----|:---------------------|:-----------:|:------------------------:|
 |Enable Fast Startup|HKLM\...\Session Manager\Power > HiberbootEnabled (dword)|0 or 1|1|
 |Show option 'Hibernation timeouts' in Advanced Power Settings|HKLM\...\Power\PowerSettings\238C9FA8-0AAD-41ED-83F4-97BE242C8F20\9d7815a6-7ee4-497e-8888-515a05f02364 > Attributes (dword)| 1|2|
 |Activate Hibernation/Fast Startup|Admin command line: `powercfg /h on`| On or Off| On|
 |Disable Core Isolation| Either in Windows Security, or Registry key: HKLM\...\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity > Enabled (dword)|1| 0|
-|Policy for devices powering down while the system is running|HKLM\...\Power\PowerSettings\4faab71a-92e5-4726-b531-224559672d19\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |0|1|
-|Disable networking in standby|HKLM\...\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |1|0|
-|Idle Power state D0 for nVidia HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <nVidia audio>\PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
-|Idle Power state D0 for AMD streaming driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <AMD audio>\PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
-|Idle Power state D0 for Realtek HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <Realtek audio>\PowerSettings > IdlePowerState (BINARY) |03000000|05FFFFFF|
+|Policy for devices powering down while the system is running|HKLM\...\Power\PowerSettings\4faab71a-92e5-4726-b531-224559672d19\DefaultPowerSchemeValues\ "Power Scheme GUID" > ACSettingIndex (dword) |0|1|
+|Disable networking in standby|HKLM\...\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\ "Power Scheme GUID" > ACSettingIndex (dword) |1|0|
+|Idle Power state D0 for nVidia HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ "nVidia audio" \PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
+|Idle Power state D0 for AMD streaming driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ "AMD audio" \PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
+|Idle Power state D0 for Realtek HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ "Realtek audio" \PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
 
 > [!IMPORTANT]
 > **REBOOT laptop to take into account changes after script is applied**

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Did set it to 3 hours like former legacy default Windows settings.
 > [!IMPORTANT]
 > Modern Standby should be ENABLED!
 >
-> If previously disabled, better to re-enable it. Should run fine now along with Hibernation 
+> If previously disabled, better to re-enable it. It can be used now along with Hibernation 
 
 All tweaks are applied to the **current Windows 11 Power Scheme** in use.
 

--- a/README.md
+++ b/README.md
@@ -87,18 +87,15 @@ Software configuration used for set up and tests:
 
 |Action|Command or Registry key: all HKLM keys expand to HKLM\SYSTEM\CurrentControlSet\Control\ |Default value|Target value set by script|
 |:-----|:---------------------|:-----------:|:------------------------:|
-|Enable Fast Startup|HKLM\..\Session Manager\Power > HiberbootEnabled (dword)|0 or 1|1|
-|Show option 'Hibernation timeouts' in Advanced Power Settings|HKLM\..\Power\PowerSettings\238C9FA8-0AAD-41ED-83F4-97BE242C8F20\9d7815a6-7ee4-497e-8888-515a05f02364 > Attributes (dword)| 1|2|
+|Enable Fast Startup|HKLM\...\Session Manager\Power > HiberbootEnabled (dword)|0 or 1|1|
+|Show option 'Hibernation timeouts' in Advanced Power Settings|HKLM\...\Power\PowerSettings\238C9FA8-0AAD-41ED-83F4-97BE242C8F20\9d7815a6-7ee4-497e-8888-515a05f02364 > Attributes (dword)| 1|2|
 |Activate Hibernation/Fast Startup|Admin command line: `powercfg /h on`| On or Off| On|
-|Disable Core Isolation| Either in Windows Security, or Registry key: HKLM\..\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity > Enabled (dword)|1| 0|
-|Policy for devices powering down while the system is running|HKLM\..\Power\PowerSettings\4faab71a-92e5-4726-b531-224559672d19\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |0|1|
-|Disable networking in standby|HKLM\..\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |1|0|
-|Idle Time AC for nVidia HDA driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0003\PowerSettings > ConservationIdleTime (BINARY) |04000000|00000000|
-|Idle Time DC for nVidia HDA driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0003\PowerSettings > PerformanceIdleTime (BINARY) |04000000|00000000|
-|Idle Time AC for AMD streaming driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0007\PowerSettings > ConservationIdleTime (BINARY) |03000000|00000000|
-|Idle Time DC for AMD streaming driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0007\PowerSettings > PerformanceIdleTime (BINARY) |03000000|00000000|
-|Idle Time AC for Realtek HDA driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0007\PowerSettings > ConservationIdleTime (BINARY) |05000000|05FFFFFF|
-|Idle Time DC for Realtek HDA driver|HKLM\..\Class\{4d36e96c-e325-11ce-bfc1-08002be10318}\0007\PowerSettings > PerformanceIdleTime (BINARY) |05000000|05FFFFFF|
+|Disable Core Isolation| Either in Windows Security, or Registry key: HKLM\...\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity > Enabled (dword)|1| 0|
+|Policy for devices powering down while the system is running|HKLM\...\Power\PowerSettings\4faab71a-92e5-4726-b531-224559672d19\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |0|1|
+|Disable networking in standby|HKLM\...\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9\DefaultPowerSchemeValues\<Power Scheme GUID> > ACSettingIndex (dword) |1|0|
+|Idle Power state D0 for nVidia HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <nVidia audio>\PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
+|Idle Power state D0 for AMD streaming driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <AMD audio>\PowerSettings > IdlePowerState (BINARY) |03000000|00000000|
+|Idle Power state D0 for Realtek HDA driver|HKLM\...\Class\\{4d36e96c-e325-11ce-bfc1-08002be10318}\ <Realtek audio>\PowerSettings > IdlePowerState (BINARY) |03000000|05FFFFFF|
 
 > [!IMPORTANT]
 > **REBOOT laptop to take into account changes after script is applied**


### PR DESCRIPTION
For Realtek Audio driver: As it does not allow to change the Idle times, changed Idle Power to D0 instead of D3. This applies both for AC and DC. Seems to work fine and persistent after reboot.